### PR TITLE
Security hardening: XSS escaping + Content-Security-Policy

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,9 @@
   // ---------- helpers ----------
   const $ = (id) => document.getElementById(id);
   const fmt = (n) => "$" + Math.round(n).toLocaleString("en-US");
+  // escape anything from outside (geocoder results, typed text) before innerHTML
+  const esc = (s) => String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
   const REDUCED = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const DESKTOP = () => window.matchMedia("(min-width: 1024px)").matches;
 
@@ -168,7 +171,7 @@
     resultsEl.innerHTML = "";
     if (!items.length) {
       resultsEl.innerHTML =
-        '<li><p class="result-empty">No matches for “' + query +
+        '<li><p class="result-empty">No matches for “' + esc(query) +
         '” — try adding your city or ZIP.</p></li>';
     }
     items.forEach((hit) => {
@@ -179,8 +182,8 @@
       btn.setAttribute("role", "option");
       btn.innerHTML =
         svgIcon("i-pin") +
-        '<span><span class="result-main">' + shortLabel(hit) + "</span>" +
-        '<span class="result-sub">' + restLabel(hit) + "</span></span>";
+        '<span><span class="result-main">' + esc(shortLabel(hit)) + "</span>" +
+        '<span class="result-sub">' + esc(restLabel(hit)) + "</span></span>";
       btn.addEventListener("click", () => {
         chooseAddress([parseFloat(hit.lat), parseFloat(hit.lon)],
           shortLabel(hit) + ", " + restLabel(hit));

--- a/index.html
+++ b/index.html
@@ -6,6 +6,24 @@
   <title>Waverly Pressure Washing — Instant Quote</title>
   <meta name="description" content="See your pressure washing price in 60 seconds and book online. No phone call needed." />
   <meta name="theme-color" content="#F8FAFC" />
+  <!-- Allowlist of everything this page may load or contact. If you add a new
+       tile/API provider in config.js, add its domain here too. -->
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'self';
+    script-src 'self';
+    style-src 'self' https://fonts.googleapis.com;
+    font-src https://fonts.gstatic.com;
+    img-src 'self' data:
+      https://server.arcgisonline.com
+      https://basemap.nationalmap.gov
+      https://clarity.maptiles.arcgis.com
+      https://api.mapbox.com;
+    connect-src 'self'
+      https://nominatim.openstreetmap.org
+      https://api.web3forms.com;
+    base-uri 'self';
+    object-src 'none';
+  " />
   <link rel="stylesheet" href="vendor/leaflet/leaflet.css" />
   <link rel="stylesheet" href="styles.css?v=4" />
 </head>
@@ -246,6 +264,6 @@
   <script src="vendor/leaflet/leaflet.js"></script>
   <script src="vendor/leaflet/leaflet.tilelayer.fallback.js"></script>
   <script src="config.js?v=6"></script>
-  <script src="app.js?v=5"></script>
+  <script src="app.js?v=6"></script>
 </body>
 </html>


### PR DESCRIPTION
- Escape address text from the Nominatim geocoder (and the echoed search query) before inserting into innerHTML — closes a potential XSS path via crafted OpenStreetMap data
- Add a Content-Security-Policy meta tag allowlisting only the origins the app actually uses (its own scripts, Google Fonts, the four tile servers, Nominatim, Web3Forms) — a script injected any other way has nowhere to phone home

Verified under headless Chrome: full quote flow works with the CSP active, and a `<img onerror>` payload typed into search renders as inert text.

https://claude.ai/code/session_01F7yDrh6SSqvzj9PWB5VxUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7yDrh6SSqvzj9PWB5VxUJ)_