### PR TITLE
Deploy to GitHub Pages on push to main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Deploys the site to GitHub Pages on every push to main, and enables Pages on the first run (`actions/configure-pages` with `enablement: true`). After merging, the site goes live at https://eaztoday.github.io/Waverly-WindowCleaning/ — the permanent URL for the postcard QR code, with correct content types (fixes the "download .txt" prompt from the raw preview host) and proper caching.

https://claude.ai/code/session_01F7yDrh6SSqvzj9PWB5VxUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7yDrh6SSqvzj9PWB5VxUJ)_